### PR TITLE
Handle selections with no text nodes properly

### DIFF
--- a/source/Editor.js
+++ b/source/Editor.js
@@ -652,6 +652,10 @@ proto._addFormat = function ( tag, attributes, range ) {
 
         do {
             textNode = walker.currentNode;
+            if (!textNode) {
+                continue;
+            }
+            
             needsFormat = !getNearest( textNode, tag, attributes );
             if ( needsFormat ) {
                 if ( textNode === endContainer &&

--- a/source/Range.js
+++ b/source/Range.js
@@ -33,10 +33,11 @@ var forEachTextNodeInRange = function ( range, fn ) {
 
     var startContainer = range.startContainer,
         endContainer = range.endContainer,
-        root = range.commonAncestorContainer,
+        root = range.startContainer === range.endContainer ?
+            range.startContainer : range.commonAncestorContainer,
         walker = new TreeWalker(
-            root, SHOW_TEXT, function (/* node */) {
-                return true;
+            root, SHOW_TEXT, function ( node ) {
+                return isNodeContainedInRange( range, node, true );
         }, false ),
         textnode = walker.currentNode = startContainer;
 


### PR DESCRIPTION
This modifies getSelectedText() and formatting functions to properly handle when the current selection does not contain any text nodes. 
