### PR TITLE
Update on paste handler

### DIFF
--- a/source/Clipboard.js
+++ b/source/Clipboard.js
@@ -61,6 +61,9 @@ var onPaste = function ( event ) {
 
         types = clipboardData && clipboardData.types;
 
+    // If we have files, use the  HTML5 Clipboard interface.
+        var hasFiles = ( types && (indexOf.call( types, 'Files') >= 0 ));
+
         // if pasted content has html data, then use code as there is no clipboard interface
         var hasHtml = (types && (indexOf.call( types, 'text/html') >= 0 ));
 
@@ -77,7 +80,7 @@ var onPaste = function ( event ) {
     // TODO: remove "hasHtml" from the if statement when Chrome versions under 52 are not supported
     // Chrome 52 : getAsString returns an empty string If we have an RTF content, so get the plain text instead
     // https://bugs.chromium.org/p/chromium/issues/detail?id=317807
-    if ( !isEdge && items && !hasHtml) {
+    if ( items && ( hasFiles || (!isEdge && !hasHtml)) {
         event.preventDefault();
         l = items.length;
         while ( l-- ) {


### PR DESCRIPTION
Allow pasting image files in Edge while preventing Edge from using the HTML5 Clipboard interface.
